### PR TITLE
Qrack issue 351

### DIFF
--- a/qrack_benchmarks.hpp
+++ b/qrack_benchmarks.hpp
@@ -9,7 +9,7 @@
 
 #include "qrack/qfactory.hpp"
 
-const int MAX_QUBITS = 28;
+const int MAX_QUBITS = 64;
 const int ITERATIONS = 100;
 const double CLOCK_FACTOR = 1000.0 / CLOCKS_PER_SEC; // Report in ms
 
@@ -60,7 +60,7 @@ void benchmarkLoopVariable(std::function<void(Qrack::QInterfacePtr, int, int)> f
 
     double avgt, stdet;
 
-    for (numBits = 4; numBits <= mxQbts; numBits++) {
+    for (numBits = 54; numBits <= 54; numBits++) {
         for (depth = minDepth; depth <= maxDepth; depth++) {
 
             if (!randQubits) {

--- a/qrack_sycamore.cpp
+++ b/qrack_sycamore.cpp
@@ -22,20 +22,16 @@ int main()
         // paper.
         std::list<bitLenInt> gateSequence = { 0, 3, 2, 1, 2, 1, 0, 3 };
 
-        // Depending on which element of the sequential tiling we're running, per depth iteration,
-        // we need to start either with row "0" or row "1".
-        std::map<bitLenInt, bitLenInt> sequenceRowStart;
-        sequenceRowStart[0] = 1;
-        sequenceRowStart[1] = 1;
-        sequenceRowStart[2] = 0;
-        sequenceRowStart[3] = 0;
-
         // We factor the qubit count into two integers, as close to a perfect square as we can.
-        int rowLen = std::sqrt(n);
-        while (((n / rowLen) * rowLen) != n) {
-            rowLen--;
+        int colLen = std::sqrt(n);
+        while (((n / colLen) * colLen) != n) {
+            colLen--;
         }
-        int colLen = n / rowLen;
+        int rowLen = n / colLen;
+
+        // std::cout<<"n="<<(int)n<<std::endl;
+        // std::cout<<"rowLen="<<(int)rowLen<<std::endl;
+        // std::cout<<"colLen="<<(int)colLen<<std::endl;
 
         // "1/6 of a full CZ" is read to indicate the 6th root of the gate operator.
         complex sixthRoot = std::pow(-ONE_CMPLX, (real1)(1.0 / 6.0));
@@ -46,8 +42,6 @@ int main()
         bitLenInt i, d;
         int row, col;
         int tempRow, tempCol;
-
-        bool startsEvenRow;
 
         bitLenInt controls[1];
 
@@ -93,10 +87,12 @@ int main()
                     gateChoices.erase(gateChoiceIterator);
 
                     gateChoiceIterator = gateChoices.begin();
-                    std::advance(gateChoiceIterator, (gateRand < (ONE_R1 / 2)) ? 0 : 1);
-                    gateChoices.erase(gateChoiceIterator);
-
-                    gateChoice = *(gateChoices.begin());
+                    if (gateRand == 1) {
+                        gateChoice = *(gateChoices.rbegin());
+                    } else {
+                        std::advance(gateChoiceIterator, (int)(gateRand * 2));
+                    }
+                    gateChoice = *gateChoiceIterator;
 
                     if (gateChoice == 0) {
                         qReg->SqrtX(i);
@@ -121,10 +117,8 @@ int main()
             gateSequence.pop_front();
             gateSequence.push_back(gate);
 
-            startsEvenRow = ((sequenceRowStart[gate] & 1U) == 0U);
-
-            for (row = sequenceRowStart[gate]; row < (n / rowLen); row += 2) {
-                for (col = 0; col < (n / colLen); col++) {
+            for (row = 1; row < rowLen; row += 2) {
+                for (col = 0; col < colLen; col++) {
                     // The following pattern is isomorphic to a 45 degree bias on a rectangle, for couplers.
                     // In this test, the boundaries of the rectangle have no couplers.
                     // In a perfect square, in the interior bulk, one 2 bit gate is applied for every pair of bits,
@@ -136,28 +130,14 @@ int main()
                     tempCol = col;
 
                     tempRow += ((gate & 2U) ? 1 : -1);
-
-                    if (startsEvenRow) {
-                        tempCol += ((gate & 1U) ? 0 : -1);
-                    } else {
-                        tempCol += ((gate & 1U) ? 1 : 0);
-                    }
+                    tempCol += (colLen == 1) ? 0 : ((gate & 1U) ? 1 : 0);
 
                     if ((tempRow < 0) || (tempCol < 0) || (tempRow >= rowLen) || (tempCol >= colLen)) {
                         continue;
                     }
 
-                    b1 = row * rowLen + col;
-                    b2 = tempRow * rowLen + tempCol;
-
-                    // For the efficiency of QUnit's mapper, we transpose the row and column.
-                    tempCol = b1 / rowLen;
-                    tempRow = b1 - (tempCol * rowLen);
-                    b1 = (tempRow * rowLen) + tempCol;
-
-                    tempCol = b2 / rowLen;
-                    tempRow = b2 - (tempCol * rowLen);
-                    b2 = (tempRow * rowLen) + tempCol;
+                    b1 = row * colLen + col;
+                    b2 = tempRow * colLen + tempCol;
 
                     // "iSWAP" is read to be a SWAP operation that imparts a phase factor of i if the bits are
                     // different.
@@ -167,12 +147,12 @@ int main()
                     qReg->ApplyControlledSinglePhase(controls, 1U, b2, ONE_CMPLX, sixthRoot);
                     // Note that these gates are both symmetric under exchange of "b1" and "b2".
 
-                    std::cout<<"("<<b1<<", "<<b2<<")"<<std::endl;
+                    // std::cout<<"("<<b1<<", "<<b2<<")"<<std::endl;
                 }
             }
-            std::cout<<"Depth++"<<std::endl;
+            // std::cout<<"Depth++"<<std::endl;
         }
-        std::cout<<"New iteration."<<std::endl;
+        // std::cout<<"New iteration."<<std::endl;
 
         // We measure all bits once, after the circuit is run.
         qReg->MReg(0, n);

--- a/qrack_sycamore.cpp
+++ b/qrack_sycamore.cpp
@@ -166,11 +166,15 @@ int main()
                     controls[0] = b1;
                     qReg->ApplyControlledSinglePhase(controls, 1U, b2, ONE_CMPLX, sixthRoot);
                     // Note that these gates are both symmetric under exchange of "b1" and "b2".
+
+                    std::cout<<"("<<b1<<", "<<b2<<")"<<std::endl;
                 }
             }
+            std::cout<<"Depth++"<<std::endl;
         }
+        std::cout<<"New iteration."<<std::endl;
 
         // We measure all bits once, after the circuit is run.
         qReg->MReg(0, n);
-    }, 1, 20);
+    }, 20, 20);
 }


### PR DESCRIPTION
Per Qrack issue 351, this fixes a bug with the "quantum supremacy" (and CCZ/CCX/H "nearest neighbor") benchmark.